### PR TITLE
chore: support Go 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ "1.23" ]
+        go-version: [ "1.23", "1.24" ]
     env:
-      GOLANGCI_LINT_VERSION: v1.61.0
+      GOLANGCI_LINT_VERSION: v1.64.6
 
     steps:
       - name: Install Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,10 +17,8 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - execinquery # deprecated
-    - exportloopref # deprecated
     - gocyclo # duplicate of cyclop
-    - gomnd # deprecated
+    - tenv # deprecated
     - depguard
     - err113
     - exhaustive


### PR DESCRIPTION
## Goal of this PR

This adds support for Go 1.24, but leaves the min go version at 1.23, to ensure no pipeline breaks for older projects.

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
