### PR TITLE
feat: add openapi 3.1 support

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -41,14 +41,13 @@ func Example() {
 	doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
 		StripPrefixes:  []string{"/internal"},
 		ObjPkgSegments: 1,
-		OpenAPIVersion: "3.0.0",
+		OpenAPIVersion: "3.1.0",
 	})
 	if err != nil {
 		log.Printf("Error: %v\n", err)
 		return
 	}
 
-	doc.OpenAPI = "3.0.0"
 	doc.Info = &kin.Info{
 		Title:   "Test Server",
 		Version: "1",

--- a/example_test.go
+++ b/example_test.go
@@ -41,6 +41,7 @@ func Example() {
 	doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
 		StripPrefixes:  []string{"/internal"},
 		ObjPkgSegments: 1,
+		OpenAPIVersion: "3.0.0",
 	})
 	if err != nil {
 		log.Printf("Error: %v\n", err)

--- a/gen.go
+++ b/gen.go
@@ -38,7 +38,9 @@ type SpecConfig struct {
 
 // BuildSpec builds openapi v3 spec from the given chi router.
 func BuildSpec(r chi.Routes, cfg SpecConfig) (kin.T, error) {
-	gen := newGenerator()
+	cfg.OpenAPIVersion = cmp.Or(cfg.OpenAPIVersion, ver)
+
+	gen := newGenerator(cfg.OpenAPIVersion)
 	gen.objPkgSegments = cfg.ObjPkgSegments
 
 	err := chi.Walk(r, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
@@ -77,10 +79,9 @@ func BuildSpec(r chi.Routes, cfg SpecConfig) (kin.T, error) {
 	}
 
 	doc := gen.doc
-	version := cmp.Or(cfg.OpenAPIVersion, ver)
-	if strings.HasPrefix(version, "3.1") {
+	if strings.HasPrefix(cfg.OpenAPIVersion, "3.1") {
 		openapi3conv.Upgrade(&doc)
-		doc.OpenAPI = version
+		doc.OpenAPI = cfg.OpenAPIVersion
 	}
 
 	return doc, nil
@@ -93,14 +94,14 @@ type generator struct {
 	objPkgSegments int
 }
 
-func newGenerator() *generator {
+func newGenerator(ver string) *generator {
 	comp := kin.NewComponents()
 	comp.Schemas = kin.Schemas{}
 	comp.SecuritySchemes = kin.SecuritySchemes{}
 
 	return &generator{
 		doc: kin.T{
-			OpenAPI:    "3.0.0",
+			OpenAPI:    ver,
 			Components: &comp,
 		},
 		gen: kingen.NewGenerator(kingen.SchemaCustomizer(customizer)),

--- a/gen.go
+++ b/gen.go
@@ -31,8 +31,7 @@ type SpecConfig struct {
 	// e.g. "3.0.0" or "3.1.0" (default). When a 3.1.x version is requested
 	// the document is upgraded via openapi3conv.Upgrade, which rewrites
 	// 3.0-specific schema constructs (nullable, boolean exclusive bounds,
-	// singular example) into their 3.1 equivalents before the version string
-	// is set.
+	// singular example) into their 3.1 equivalents.
 	OpenAPIVersion string
 }
 

--- a/gen.go
+++ b/gen.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"cmp"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -10,9 +11,12 @@ import (
 	"unicode"
 
 	kin "github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3conv"
 	kingen "github.com/getkin/kin-openapi/openapi3gen"
 	"github.com/go-chi/chi/v5"
 )
+
+const ver = "3.1.0"
 
 // SpecConfig configures how the spec is built.
 type SpecConfig struct {
@@ -22,6 +26,14 @@ type SpecConfig struct {
 	// ObjPkgSegments determines the maximum number of
 	// package segments to use to identify an object.
 	ObjPkgSegments int
+
+	// OpenAPIVersion sets the OpenAPI version string in the output document,
+	// e.g. "3.0.0" or "3.1.0" (default). When a 3.1.x version is requested
+	// the document is upgraded via openapi3conv.Upgrade, which rewrites
+	// 3.0-specific schema constructs (nullable, boolean exclusive bounds,
+	// singular example) into their 3.1 equivalents before the version string
+	// is set.
+	OpenAPIVersion string
 }
 
 // BuildSpec builds openapi v3 spec from the given chi router.
@@ -63,7 +75,15 @@ func BuildSpec(r chi.Routes, cfg SpecConfig) (kin.T, error) {
 	if err != nil {
 		return kin.T{}, err
 	}
-	return gen.doc, nil
+
+	doc := gen.doc
+	version := cmp.Or(cfg.OpenAPIVersion, ver)
+	if strings.HasPrefix(version, "3.1") {
+		openapi3conv.Upgrade(&doc)
+		doc.OpenAPI = version
+	}
+
+	return doc, nil
 }
 
 type generator struct {

--- a/gen_test.go
+++ b/gen_test.go
@@ -39,7 +39,7 @@ func TestBuildSpec(t *testing.T) {
 			Produces("application/json", "application/xml").
 			Returns(http.StatusOK, "OK", &TestObject{}, openapi.WithResponseHeader("X-Request-Id")).
 			Returns(http.StatusNotFound, "Missing", &TestGenericObject[TestSimpleObject]{}).
-			Returns(http.StatusConflict, "Conflict", "", openapi.WithMediaTypes("application/octet-steam"))
+			Returns(http.StatusConflict, "Conflict", "", openapi.WithMediaTypes("application/octet-stream"))
 
 		r.With(op.Build()).Post("/test/{name}", func(rw http.ResponseWriter, req *http.Request) {})
 	})
@@ -60,7 +60,7 @@ func TestBuildSpec(t *testing.T) {
 			Produces("application/json", "application/xml").
 			Returns(http.StatusOK, "OK", &TestObject{}, openapi.WithResponseHeader("X-Request-Id")).
 			Returns(http.StatusNotFound, "Missing", &TestGenericObject[TestSimpleObject]{}).
-			Returns(http.StatusConflict, "Conflict", "", openapi.WithMediaTypes("application/octet-steam"))
+			Returns(http.StatusConflict, "Conflict", "", openapi.WithMediaTypes("application/octet-stream"))
 
 		r.With(op.Build()).Post("/test/{name}", func(rw http.ResponseWriter, req *http.Request) {})
 	})

--- a/gen_test.go
+++ b/gen_test.go
@@ -117,7 +117,6 @@ func TestBuildSpec(t *testing.T) {
 			doc, err := openapi.BuildSpec(mux, test.specConfig)
 			require.NoError(t, err)
 
-			doc.OpenAPI = "3.0.0"
 			doc.Info = &kin.Info{
 				Title:   "Test Server",
 				Version: "1",

--- a/gen_test.go
+++ b/gen_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/gamefabric/openapi"
@@ -68,14 +67,54 @@ func TestBuildSpec(t *testing.T) {
 
 	mux.Get("/internal/handler", testHandler())
 
-	for i := range 2 {
-		t.Run("pkg segments "+strconv.Itoa(i), func(t *testing.T) {
+	tests := []struct {
+		name          string
+		specConfig    openapi.SpecConfig
+		wantMatchFile string
+	}{
+		{
+			name: "generates openapi v3.0.0, first segment",
+			specConfig: openapi.SpecConfig{
+				StripPrefixes:  []string{"/internal"},
+				ObjPkgSegments: 0,
+				OpenAPIVersion: "3.0.0",
+			},
+			wantMatchFile: "testdata/spec-pkgseg0.json",
+		},
+		{
+			name: "generates openapi v3.0.0, second segment",
+			specConfig: openapi.SpecConfig{
+				StripPrefixes:  []string{"/internal"},
+				ObjPkgSegments: 1,
+				OpenAPIVersion: "3.0.0",
+			},
+			wantMatchFile: "testdata/spec.json",
+		},
+		{
+			name: "generates openapi v3.1.0, first segment",
+			specConfig: openapi.SpecConfig{
+				StripPrefixes:  []string{"/internal"},
+				ObjPkgSegments: 0,
+				OpenAPIVersion: "3.1.0",
+			},
+			wantMatchFile: "testdata/spec-pkgseg0-3.1.0.json",
+		},
+		{
+			name: "generates openapi v3.1.0, second segment",
+			specConfig: openapi.SpecConfig{
+				StripPrefixes:  []string{"/internal"},
+				ObjPkgSegments: 1,
+				OpenAPIVersion: "3.1.0",
+			},
+			wantMatchFile: "testdata/spec-3.1.0.json",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
-				StripPrefixes:  []string{"/internal"},
-				ObjPkgSegments: i,
-			})
+			doc, err := openapi.BuildSpec(mux, test.specConfig)
 			require.NoError(t, err)
 
 			doc.OpenAPI = "3.0.0"
@@ -86,16 +125,11 @@ func TestBuildSpec(t *testing.T) {
 			got, err := json.MarshalIndent(doc, "", "  ")
 			require.NoError(t, err)
 
-			name := "testdata/spec.json"
-			if i != 1 {
-				name = "testdata/spec-pkgseg" + strconv.Itoa(i) + ".json"
-			}
-
 			if *update {
-				_ = os.WriteFile(name, got, 0o644)
+				_ = os.WriteFile(test.wantMatchFile, got, 0o644)
 			}
 
-			want, err := os.ReadFile(name)
+			want, err := os.ReadFile(test.wantMatchFile)
 			require.NoError(t, err)
 			assert.Equal(t, string(want), string(got))
 		})
@@ -148,6 +182,7 @@ func TestBuildSpecSecurity(t *testing.T) {
 
 	doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
 		ObjPkgSegments: 1,
+		OpenAPIVersion: "3.0.0",
 	})
 	require.NoError(t, err)
 
@@ -256,6 +291,7 @@ func TestDescribeField(t *testing.T) {
 
 	doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
 		ObjPkgSegments: 1,
+		OpenAPIVersion: "3.0.0",
 	})
 	require.NoError(t, err)
 

--- a/testdata/spec-3.1.0.json
+++ b/testdata/spec-3.1.0.json
@@ -172,7 +172,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }
@@ -336,7 +336,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }

--- a/testdata/spec-3.1.0.json
+++ b/testdata/spec-3.1.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "components": {
     "schemas": {
       "openapi_test.TestGenericObject[openapi_test.TestSimpleObject]": {
@@ -19,11 +19,13 @@
         "type": "object"
       },
       "openapi_test.TestObject": {
-        "example": {
-          "test1": "a",
-          "test2": "b",
-          "test3": "c"
-        },
+        "examples": [
+          {
+            "test1": "a",
+            "test2": "b",
+            "test3": "c"
+          }
+        ],
         "properties": {
           "test1": {
             "description": "Test1 is an documented field with \u0026#34;quotes\u0026#34;\nand a newline.",

--- a/testdata/spec-3.1.0.json
+++ b/testdata/spec-3.1.0.json
@@ -1,0 +1,353 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "openapi_test.TestGenericObject[openapi_test.TestSimpleObject]": {
+        "properties": {
+          "test1": {
+            "properties": {
+              "test1": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "test2": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "openapi_test.TestObject": {
+        "example": {
+          "test1": "a",
+          "test2": "b",
+          "test3": "c"
+        },
+        "properties": {
+          "test1": {
+            "description": "Test1 is an documented field with \u0026#34;quotes\u0026#34;\nand a newline.",
+            "type": "string"
+          },
+          "test2": {
+            "readOnly": true,
+            "type": "string"
+          },
+          "test3": {
+            "type": "string"
+          },
+          "test4": {
+            "enum": [
+              "192.168.1.0",
+              "192.168.1.1"
+            ],
+            "format": "ipv4",
+            "type": "string"
+          },
+          "test5": {
+            "items": {
+              "enum": [
+                "alpha",
+                "beta"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "test3"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Test Server",
+    "version": "1"
+  },
+  "paths": {
+    "/api/test/{name}": {
+      "post": {
+        "operationId": "test-id",
+        "parameters": [
+          {
+            "description": "the item name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the filter number",
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the customer param",
+            "in": "query",
+            "name": "custom",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "deprecated": true,
+            "description": "the deprecated param",
+            "in": "query",
+            "name": "deprecated",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the header authorization param",
+            "in": "header",
+            "name": "Authorization"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi_test.TestObject"
+              }
+            },
+            "text/html": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi_test.TestObject"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi_test.TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestObject"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestObject"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "in": "header",
+                "name": "X-Request-Id"
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestGenericObject[openapi_test.TestSimpleObject]"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestGenericObject[openapi_test.TestSimpleObject]"
+                }
+              }
+            },
+            "description": "Missing"
+          },
+          "409": {
+            "content": {
+              "application/octet-steam": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "test",
+        "tags": [
+          "test-tag"
+        ]
+      }
+    },
+    "/handler": {
+      "get": {
+        "operationId": "test-handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "test": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "204": {
+            "description": "OK"
+          }
+        },
+        "summary": "test handler",
+        "tags": [
+          "handler"
+        ]
+      }
+    },
+    "/old/api/test/{name}": {
+      "post": {
+        "deprecated": true,
+        "operationId": "old-test-id",
+        "parameters": [
+          {
+            "description": "the item name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the filter number",
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the customer param",
+            "in": "query",
+            "name": "custom",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "deprecated": true,
+            "description": "the deprecated param",
+            "in": "query",
+            "name": "deprecated",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the header authorization param",
+            "in": "header",
+            "name": "Authorization"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi_test.TestObject"
+              }
+            },
+            "text/html": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi_test.TestObject"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/openapi_test.TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestObject"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestObject"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "in": "header",
+                "name": "X-Request-Id"
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestGenericObject[openapi_test.TestSimpleObject]"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/openapi_test.TestGenericObject[openapi_test.TestSimpleObject]"
+                }
+              }
+            },
+            "description": "Missing"
+          },
+          "409": {
+            "content": {
+              "application/octet-steam": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "old test",
+        "tags": [
+          "old-test-tag"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/spec-pkgseg0-3.1.0.json
+++ b/testdata/spec-pkgseg0-3.1.0.json
@@ -172,7 +172,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }
@@ -336,7 +336,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }

--- a/testdata/spec-pkgseg0-3.1.0.json
+++ b/testdata/spec-pkgseg0-3.1.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "components": {
     "schemas": {
       "TestGenericObject[TestSimpleObject]": {
@@ -19,11 +19,13 @@
         "type": "object"
       },
       "TestObject": {
-        "example": {
-          "test1": "a",
-          "test2": "b",
-          "test3": "c"
-        },
+        "examples": [
+          {
+            "test1": "a",
+            "test2": "b",
+            "test3": "c"
+          }
+        ],
         "properties": {
           "test1": {
             "description": "Test1 is an documented field with \u0026#34;quotes\u0026#34;\nand a newline.",

--- a/testdata/spec-pkgseg0-3.1.0.json
+++ b/testdata/spec-pkgseg0-3.1.0.json
@@ -1,0 +1,353 @@
+{
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "TestGenericObject[TestSimpleObject]": {
+        "properties": {
+          "test1": {
+            "properties": {
+              "test1": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "test2": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TestObject": {
+        "example": {
+          "test1": "a",
+          "test2": "b",
+          "test3": "c"
+        },
+        "properties": {
+          "test1": {
+            "description": "Test1 is an documented field with \u0026#34;quotes\u0026#34;\nand a newline.",
+            "type": "string"
+          },
+          "test2": {
+            "readOnly": true,
+            "type": "string"
+          },
+          "test3": {
+            "type": "string"
+          },
+          "test4": {
+            "enum": [
+              "192.168.1.0",
+              "192.168.1.1"
+            ],
+            "format": "ipv4",
+            "type": "string"
+          },
+          "test5": {
+            "items": {
+              "enum": [
+                "alpha",
+                "beta"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "test3"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Test Server",
+    "version": "1"
+  },
+  "paths": {
+    "/api/test/{name}": {
+      "post": {
+        "operationId": "test-id",
+        "parameters": [
+          {
+            "description": "the item name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the filter number",
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the customer param",
+            "in": "query",
+            "name": "custom",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "deprecated": true,
+            "description": "the deprecated param",
+            "in": "query",
+            "name": "deprecated",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the header authorization param",
+            "in": "header",
+            "name": "Authorization"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            },
+            "text/html": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "in": "header",
+                "name": "X-Request-Id"
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestGenericObject[TestSimpleObject]"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestGenericObject[TestSimpleObject]"
+                }
+              }
+            },
+            "description": "Missing"
+          },
+          "409": {
+            "content": {
+              "application/octet-steam": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "test",
+        "tags": [
+          "test-tag"
+        ]
+      }
+    },
+    "/handler": {
+      "get": {
+        "operationId": "test-handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "test": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "204": {
+            "description": "OK"
+          }
+        },
+        "summary": "test handler",
+        "tags": [
+          "handler"
+        ]
+      }
+    },
+    "/old/api/test/{name}": {
+      "post": {
+        "deprecated": true,
+        "operationId": "old-test-id",
+        "parameters": [
+          {
+            "description": "the item name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "the filter number",
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the customer param",
+            "in": "query",
+            "name": "custom",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "deprecated": true,
+            "description": "the deprecated param",
+            "in": "query",
+            "name": "deprecated",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "the header authorization param",
+            "in": "header",
+            "name": "Authorization"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            },
+            "text/html": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "in": "header",
+                "name": "X-Request-Id"
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestGenericObject[TestSimpleObject]"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestGenericObject[TestSimpleObject]"
+                }
+              }
+            },
+            "description": "Missing"
+          },
+          "409": {
+            "content": {
+              "application/octet-steam": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "old test",
+        "tags": [
+          "old-test-tag"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/spec-pkgseg0.json
+++ b/testdata/spec-pkgseg0.json
@@ -170,7 +170,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }
@@ -334,7 +334,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -170,7 +170,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }
@@ -334,7 +334,7 @@
           },
           "409": {
             "content": {
-              "application/octet-steam": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string"
                 }


### PR DESCRIPTION
## Goal of this PR

Support openapi v3.1.0 support.

## How did I test it?

Unit tests & use it with gf-core. See https://github.com/GameFabric/gf-core/pull/865 (that PR will be closed after this has been acknowledged).