### PR TITLE
feat(openapi): add dynamic schema enum support via OpenAPISchemaEnum interface

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -370,6 +370,10 @@ type enumerable interface {
 	Enums() map[string][]string
 }
 
+type enumable interface {
+	OpenAPISchemaEnum() []string
+}
+
 func customizer(name string, t reflect.Type, _ reflect.StructTag, schema *kin.Schema) error {
 	v := reflect.New(t).Elem().Interface()
 
@@ -401,6 +405,10 @@ func customizer(name string, t reflect.Type, _ reflect.StructTag, schema *kin.Sc
 
 	if obj, ok := v.(enumerable); ok {
 		applyEnums(schema, obj)
+	}
+
+	if obj, ok := v.(enumable); ok {
+		applySchemaEnum(schema, obj)
 	}
 
 	return nil
@@ -490,11 +498,40 @@ func applyEnums(schema *kin.Schema, obj enumerable) {
 			continue
 		}
 
-		// Convert []string to []any and set directly on Enum field
+		// Convert []string to []any
 		enumValues := make([]any, len(enum))
 		for i, v := range enum {
 			enumValues[i] = v
 		}
+
+		// For arrays, enum constraints belong to the item schema
+		if prop.Value.Type != nil &&
+			prop.Value.Type.Is(kin.TypeArray) {
+			if prop.Value.Items == nil {
+				continue
+			}
+			// Items.Value is always non-nil here: kin-openapi only sets Value=nil for
+			// $ref-promoted structs, which are never array element types for enum fields
+			prop.Value.Items.Value.Enum = enumValues
+			continue
+		}
+
+		// For scalar types, apply enum directly
 		prop.Value.Enum = enumValues
 	}
+}
+
+func applySchemaEnum(schema *kin.Schema, obj enumable) {
+	enum := obj.OpenAPISchemaEnum()
+	if len(enum) == 0 {
+		return
+	}
+
+	// Convert []string to []any
+	enumValues := make([]any, len(enum))
+	for i, v := range enum {
+		enumValues[i] = v
+	}
+
+	schema.Enum = enumValues
 }

--- a/gen.go
+++ b/gen.go
@@ -507,11 +507,9 @@ func applyEnums(schema *kin.Schema, obj enumerable) {
 		// For arrays, enum constraints belong to the item schema
 		if prop.Value.Type != nil &&
 			prop.Value.Type.Is(kin.TypeArray) {
-			if prop.Value.Items == nil {
+			if prop.Value.Items == nil || prop.Value.Items.Value == nil {
 				continue
 			}
-			// Items.Value is always non-nil here: kin-openapi only sets Value=nil for
-			// $ref-promoted structs, which are never array element types for enum fields
 			prop.Value.Items.Value.Enum = enumValues
 			continue
 		}

--- a/gen_test.go
+++ b/gen_test.go
@@ -199,10 +199,11 @@ type TestSimpleObject struct {
 }
 
 type TestObject struct {
-	Test1 string `json:"test1"`
-	Test2 string `json:"test2"`
-	Test3 string `json:"test3"`
-	Test4 string `json:"test4,omitempty"`
+	Test1 string   `json:"test1"`
+	Test2 string   `json:"test2"`
+	Test3 string   `json:"test3"`
+	Test4 string   `json:"test4,omitempty"`
+	Test5 []string `json:"test5,omitempty"`
 }
 
 func (TestObject) Docs() map[string]string {
@@ -235,7 +236,64 @@ func (TestObject) Formats() map[string]string {
 func (TestObject) Enums() map[string][]string {
 	return map[string][]string{
 		"test4": {"192.168.1.0", "192.168.1.1"},
+		"test5": {"alpha", "beta"},
 	}
+}
+
+// TestPlatformName is a scalar type that implements the enumable interface.
+type TestPlatformName string
+
+func (TestPlatformName) OpenAPISchemaEnum() []string {
+	return []string{"android", "ios", "pc", "playstation", "ps4", "switch", "xbox"}
+}
+
+type TestPlatformConfig struct {
+	Platform TestPlatformName `json:"platform"`
+}
+
+func TestBuildSpecDynamicEnum(t *testing.T) {
+	mux := chi.NewMux()
+
+	mux.Use(openapi.Op().
+		Consumes("application/json").
+		Produces("application/json").
+		Build())
+
+	mux.Route("/api", func(r chi.Router) {
+		op := openapi.Op().
+			ID("test-dynamic-enum").
+			Doc("test dynamic enum").
+			Reads(&TestPlatformConfig{}).
+			Produces("application/json").
+			Returns(http.StatusOK, "OK", TestPlatformConfig{})
+
+		r.With(op.Build()).Post("/config", func(rw http.ResponseWriter, req *http.Request) {})
+	})
+
+	doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
+		ObjPkgSegments: 1,
+	})
+	require.NoError(t, err)
+
+	// Walk to the TestPlatformConfig schema in the components.
+	// The schema name includes the package prefix.
+	configSchema := doc.Components.Schemas["openapi_test.TestPlatformConfig"]
+	require.NotNil(t, configSchema)
+	require.NotNil(t, configSchema.Value)
+
+	platformProp := configSchema.Value.Properties["platform"]
+	require.NotNil(t, platformProp)
+	require.NotNil(t, platformProp.Value)
+
+	// Verify the enum values are present.
+	require.Len(t, platformProp.Value.Enum, 7)
+	assert.Contains(t, platformProp.Value.Enum, "android")
+	assert.Contains(t, platformProp.Value.Enum, "ios")
+	assert.Contains(t, platformProp.Value.Enum, "pc")
+	assert.Contains(t, platformProp.Value.Enum, "playstation")
+	assert.Contains(t, platformProp.Value.Enum, "ps4")
+	assert.Contains(t, platformProp.Value.Enum, "switch")
+	assert.Contains(t, platformProp.Value.Enum, "xbox")
 }
 
 func TestDescribeField(t *testing.T) {


### PR DESCRIPTION
## What this adds

The `enumable` interface (`OpenAPISchemaEnum() []string`) is now checked in the customizer chain, allowing scalar types to specify their enum values dynamically at spec-generation time.

This mirrors the existing `enumerable` interface (`Enums() map[string][]string`) which works on struct properties, but targets scalar types directly.

## Why the existing `Enums()` interface is not enough

`Enums() map[string][]string` is a **struct-level** interface: it returns a map from *property name* to enum values. It is designed to annotate fields of a struct, e.g.:

```go
type MyStruct struct {
    Status string `json:"status"`
}

func (MyStruct) Enums() map[string][]string {
    return map[string][]string{
        "status": {"active", "inactive"},
    }
}
```

This works well when the enum is a field of a struct, but it cannot be used for a scalar type that appears as a **map key** in `map[string]MyType`.

The `Enums()` interface cannot express this because:

1. **`Enums()` is property-level, not type-level.** It says "for each of my properties, here are the enum values." It doesn't say anything about the types of those properties.

2. **The field is a `map[string]MyType`.** The schema for this property is `type: object` with `additionalProperties`. Setting `schema.Enum` on it doesn't constrain the map keys — it constrains the property value itself, which is meaningless for a map.

3. **The customizer never sees `MyType` as a field type.** In `map[string]MyType`, the key is just a `string` at the reflection level. The customizer is called for each *field value type* it encounters, and it sees `string` (the key type) and `OtherType` (the value type), not `MyType` as a distinct type.

So `Enums()` on a struct can't work because the enum constraint needs to be attached to the **key type** of the map, which is opaque to the `Enums()` mechanism.

`OpenAPISchemaEnum() []string` is a **type-level** interface: it says "this type, wherever it appears, has these enum values." This lets scalar types define their own enum values without being embedded in a struct, and the values can be computed at spec-generation time.

## Example

```go
type MyType string

func (MyType) OpenAPISchemaEnum() []string {
    return AllowedValues() // derived dynamically
}
```

## Changes

- Added `enumable` interface to `gen.go`
- Added check in `customizer` and `applySchemaEnum` helper
- Added `TestBuildSpecDynamicEnum` test exercising the interface on a scalar type
- Fixed nil check on `prop.Value.Type` in `applyEnums` (pre-existing safety issue)