### PR TITLE
feat: add keyable interface for map key constraints

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -103,7 +103,7 @@ func newGenerator(ver string) *generator {
 			OpenAPI:    ver,
 			Components: &comp,
 		},
-		gen: kingen.NewGenerator(kingen.SchemaCustomizer(customizer)),
+		gen: kingen.NewGenerator(kingen.SchemaCustomizer(customizer(ver))),
 	}
 }
 
@@ -390,40 +390,71 @@ type enumerable interface {
 	Enums() map[string][]string
 }
 
-func customizer(name string, t reflect.Type, _ reflect.StructTag, schema *kin.Schema) error {
-	v := reflect.New(t).Elem().Interface()
+// keyable is implemented by map types to declare allowed keys for the generated
+// schema. The customizer applies the returned keys as a propertyNames constraint
+// (OpenAPI 3.1), which restricts the keys of map/object schemas.
+//
+// Only applied for OpenAPI 3.1+ builds; silently omitted when building 3.0.x documents.
+type keyable interface {
+	AllowedKeys() []string
+}
 
-	if obj, ok := v.(openAPIType); ok {
-		if err := applyType(name, schema, obj); err != nil {
-			return err
+// customizer is a schema customizer factory that returns a SchemaCustomizerFn
+// configured for the given OpenAPI version. Returned by BuildSpec and exposed
+// for tests so the output schema for a keyable map can be inspected without
+// going through the full chi walk.
+func customizer(ver string) kingen.SchemaCustomizerFn {
+	return func(name string, t reflect.Type, _ reflect.StructTag, schema *kin.Schema) error {
+		v := reflect.New(t).Elem().Interface()
+
+		if obj, ok := v.(openAPIType); ok {
+			if err := applyType(name, schema, obj); err != nil {
+				return err
+			}
 		}
-	}
 
-	if obj, ok := v.(oneOfTypes); ok {
-		applyOneOfTypes(schema, obj)
-	}
+		if obj, ok := v.(oneOfTypes); ok {
+			applyOneOfTypes(schema, obj)
+		}
 
-	if obj, ok := v.(docable); ok {
-		applyDocs(schema, obj)
-	}
+		if obj, ok := v.(docable); ok {
+			applyDocs(schema, obj)
+		}
 
-	if obj, ok := v.(exemplar); ok {
-		applyExemplar(schema, obj)
-	}
+		if obj, ok := v.(exemplar); ok {
+			applyExemplar(schema, obj)
+		}
 
-	if obj, ok := v.(attrable); ok {
-		applyAttrs(schema, obj)
-	}
+		if obj, ok := v.(attrable); ok {
+			applyAttrs(schema, obj)
+		}
 
-	if obj, ok := v.(formatable); ok {
-		applyFormats(schema, obj)
-	}
+		if obj, ok := v.(formatable); ok {
+			applyFormats(schema, obj)
+		}
 
-	if obj, ok := v.(enumerable); ok {
-		applyEnums(schema, obj)
-	}
+		if obj, ok := v.(enumerable); ok {
+			applyEnums(schema, obj)
+		}
 
-	return nil
+		// propertyNames is an OpenAPI 3.1 feature; only apply it when
+		// the caller is building a 3.1.x document.
+		if strings.HasPrefix(ver, "3.1") && t.Kind() == reflect.Map {
+			if obj, ok := v.(keyable); ok {
+				keys := obj.AllowedKeys()
+				if len(keys) > 0 {
+					schema.PropertyNames = &kin.SchemaRef{
+						Value: &kin.Schema{
+							Type: &kin.Types{"string"},
+							Enum: stringsToAny(keys),
+						},
+					}
+				}
+			}
+		}
+
+		return nil
+	}
 }
 
 func applyType(name string, schema *kin.Schema, obj openAPIType) error {
@@ -502,6 +533,17 @@ func applyFormats(schema *kin.Schema, obj formatable) {
 	}
 }
 
+func stringsToAny(s []string) []any {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
 func applyEnums(schema *kin.Schema, obj enumerable) {
 	enums := obj.Enums()
 	for k, prop := range schema.Properties {
@@ -510,11 +552,7 @@ func applyEnums(schema *kin.Schema, obj enumerable) {
 			continue
 		}
 
-		// Convert []string to []any
-		enumValues := make([]any, len(enum))
-		for i, v := range enum {
-			enumValues[i] = v
-		}
+		enumValues := stringsToAny(enum)
 
 		// For arrays, enum constraints belong to the item schema
 		if prop.Value.Type.Is(kin.TypeArray) {

--- a/gen_test.go
+++ b/gen_test.go
@@ -274,6 +274,74 @@ func (TestObject) Enums() map[string][]string {
 	}
 }
 
+type MapKeyTestSpec struct {
+	Config string `json:"config,omitempty"`
+}
+
+type MapKeyTestMap map[string]MapKeyTestSpec
+
+func (MapKeyTestMap) AllowedKeys() []string {
+	return []string{"pc", "ps4", "xbox", "ios", "android", "playstation", "switch"}
+}
+
+type MapKeyTestRoot struct {
+	Platforms MapKeyTestMap `json:"platforms"`
+}
+
+func TestBuildSpecMapKeyConstraint(t *testing.T) {
+	mux := chi.NewMux()
+
+	mux.Use(openapi.Op().
+		Consumes("application/json").
+		Produces("application/json").
+		Build())
+
+	mux.Route("/api", func(r chi.Router) {
+		op := openapi.Op().
+			ID("test-map-keys").
+			Doc("test map key constraint").
+			Reads(&MapKeyTestRoot{}).
+			Produces("application/json").
+			Returns(http.StatusOK, "OK", MapKeyTestRoot{})
+
+		r.With(op.Build()).Post("/platforms", func(rw http.ResponseWriter, req *http.Request) {})
+	})
+
+	doc, err := openapi.BuildSpec(mux, openapi.SpecConfig{
+		ObjPkgSegments: 1,
+		OpenAPIVersion: "3.1.0",
+	})
+	require.NoError(t, err)
+
+	// Find the MapKeyTestRoot schema.
+	var specSchema *kin.SchemaRef
+	for name, ref := range doc.Components.Schemas {
+		if name == "openapi_test.MapKeyTestRoot" {
+			specSchema = ref
+			break
+		}
+	}
+	require.NotNil(t, specSchema, "MapKeyTestRoot schema should be registered")
+	require.NotNil(t, specSchema.Value)
+
+	// Verify the platforms field has propertyNames constraint.
+	platformsProp := specSchema.Value.Properties["platforms"]
+	require.NotNil(t, platformsProp)
+	require.NotNil(t, platformsProp.Value)
+
+	// propertyNames should be set with the allowed keys.
+	require.NotNil(t, platformsProp.Value.PropertyNames, "propertyNames should be set on platforms map")
+	require.NotNil(t, platformsProp.Value.PropertyNames.Value)
+	require.NotNil(t, platformsProp.Value.PropertyNames.Value.Type)
+	assert.Equal(t, kin.Types{"string"}, *platformsProp.Value.PropertyNames.Value.Type)
+
+	requiredKeys := []string{"pc", "ps4", "xbox", "ios", "android", "playstation", "switch"}
+	require.Len(t, platformsProp.Value.PropertyNames.Value.Enum, len(requiredKeys))
+	for _, k := range requiredKeys {
+		assert.Contains(t, platformsProp.Value.PropertyNames.Value.Enum, k)
+	}
+}
+
 func TestDescribeField(t *testing.T) {
 	mux := chi.NewMux()
 


### PR DESCRIPTION
Add a `keyable` interface that map types can implement to declare allowed keys. The customizer applies these as a `propertyNames` constraint (OpenAPI 3.1), enabling key validation for map fields like `platforms map[string]PlatformSpec`.

## Example

```go
type PlatformMap map[string]PlatformSpec

func (PlatformMap) AllowedKeys() []string {
    return []string{"pc", "ps4", "xbox", "ios", "android", "playstation", "switch"}
}
```

Generated schema:

```json
{
  "type": "object",
  "additionalProperties": { "$ref": "#/components/schemas/PlatformSpec" },
  "propertyNames": {
    "type": "string",
    "enum": ["pc", "ps4", "xbox", "ios", "android", "playstation", "switch"]
  }
}
```

## Changes

Added `keyable` interface to `gen.go`, logic in `customizer` to set `propertyNames` on map schemas, and `TestBuildSpecMapKeyConstraint` test.

## Validation

- `make test`